### PR TITLE
Fix error message for attempting to access a SOp annotation that doesn't exist.

### DIFF
--- a/tracr/compiler/craft_model_to_transformer.py
+++ b/tracr/compiler/craft_model_to_transformer.py
@@ -35,11 +35,6 @@ def craft_model_to_transformer(
   """Turn a craft model into a transformer model."""
 
   # Add the compiler BOS token.
-  if rasp.tokens.label not in graph.nodes:
-    raise ValueError(f"Failed to find a node with label {rasp.tokens.label}. "
-                     "This is probably because the RASP program does not contain rasp.tokens. "
-                     "A program must contain rasp.tokens to be compilable.")
-
   tokens_value_set = (
       graph.nodes[rasp.tokens.label][nodes.VALUE_SET].union(
           {compiler_bos, compiler_pad}))

--- a/tracr/compiler/craft_model_to_transformer.py
+++ b/tracr/compiler/craft_model_to_transformer.py
@@ -35,6 +35,11 @@ def craft_model_to_transformer(
   """Turn a craft model into a transformer model."""
 
   # Add the compiler BOS token.
+  if rasp.tokens.label not in graph.nodes:
+    raise ValueError(f"Failed to find a node with label {rasp.tokens.label}. "
+                     "This is probably because the RASP program does not contain rasp.tokens. "
+                     "A program must contain rasp.tokens to be compilable.")
+
   tokens_value_set = (
       graph.nodes[rasp.tokens.label][nodes.VALUE_SET].union(
           {compiler_bos, compiler_pad}))

--- a/tracr/rasp/rasp.py
+++ b/tracr/rasp/rasp.py
@@ -89,7 +89,7 @@ class _Annotations(collections.abc.Mapping):
       if key not in DEFAULT_ANNOTATORS:
         raise KeyError(
             f"No annotation exists for key '{key}'. "
-            f"Available keys: {list(*self.keys(), *DEFAULT_ANNOTATORS.keys())}")
+            f"Available keys: {list(self.keys()) + list(DEFAULT_ANNOTATORS.keys())}")
       self._inner_dict[key] = DEFAULT_ANNOTATORS[key](self._expr)
 
     return self._inner_dict[key]


### PR DESCRIPTION
The error message for accessing a nonexistent annotation calls `list` using multiple arguments, but `list` only expects a single argument. Fixed by this pull request.