### PR TITLE
add checks to prevent negative outputs of map fst's that will be set to zero by the ReLU activation

### DIFF
--- a/tracr/compiler/basis_inference.py
+++ b/tracr/compiler/basis_inference.py
@@ -57,6 +57,8 @@ def infer_bases(
         res = errors.ignoring_arithmetic_errors(sop.f)(x)
         if res is not None:
           out.add(res)
+      if not all(x >= 0 for x in out):
+        raise ValueError(f"Map does not support negative outputs due to the ReLU activation\noutputs: {out}\nsop: {sop}")
       return out
     elif isinstance(sop, rasp.SequenceMap):
       f_ignore_error = errors.ignoring_arithmetic_errors(sop.f)

--- a/tracr/compiler/basis_inference.py
+++ b/tracr/compiler/basis_inference.py
@@ -57,7 +57,7 @@ def infer_bases(
         res = errors.ignoring_arithmetic_errors(sop.f)(x)
         if res is not None:
           out.add(res)
-      if not all(x >= 0 for x in out):
+      if rasp.is_numerical(sop) and (not all(x >= 0 for x in out)):
         raise ValueError(f"Map does not support negative outputs due to the ReLU activation\noutputs: {out}\nsop: {sop}")
       return out
     elif isinstance(sop, rasp.SequenceMap):

--- a/tracr/compiler/validating.py
+++ b/tracr/compiler/validating.py
@@ -156,7 +156,7 @@ class DynamicValidationEvaluator(rasp.DefaultRASPEvaluator):
         )
 
     elif isinstance(expr, rasp.Map):
-      if not all(x >= 0 for x in out):
+      if rasp.is_numerical(expr) and (not all(x >= 0 for x in out)):
         self.unsupported_exprs.append(
           TracrUnsupportedExpr(
                 expr=expr,

--- a/tracr/compiler/validating.py
+++ b/tracr/compiler/validating.py
@@ -155,6 +155,18 @@ class DynamicValidationEvaluator(rasp.DefaultRASPEvaluator):
             )
         )
 
+    elif isinstance(expr, rasp.Map):
+      if not all(x >= 0 for x in out):
+        self.unsupported_exprs.append(
+          TracrUnsupportedExpr(
+                expr=expr,
+                reason=(
+                    "Map only supports positive outputs due to the ReLU activation"
+                    f" got {set(out)}."
+                ),
+          )
+        )
+    
     return out
 
 


### PR DESCRIPTION
Currently there is no validation check to prevent negative values being produced by a Map operation, these will get set to 0 by the ReLU in MLP layers and cause craft models to behave unexpectedly.

The simplest example that would cause this is a program like this:
```
def test_prog():
    SO1 = rasp.Map(lambda x: x - 1, rasp.tokens).annotated(name="SO1", encoding=rasp.Encoding.NUMERICAL)
    return SO1
vocab = [0, 1]
sequence_length = 1
```

you would expect the model to output -1 and 0 for inputs 0 and 1, but instead the craft model will output 0 and 0.

I have added a validation check within the dynamic program validator and added an exception into the compiler that will throw an error if any negative values are found at the output of the first layer of a Map MLP.