### PR TITLE
long selector width mismatch between rasp and craft potentially due to BOS token

### DIFF
--- a/tracr/compiler/test_cases.py
+++ b/tracr/compiler/test_cases.py
@@ -390,6 +390,17 @@ CAUSAL_TEST_CASES = UNIVERSAL_TEST_CASES + [
         expected_output=[1, 2, 3, 4],
         max_seq_len=5,
     ),
+    
+    dict(
+        testcase_name="selector_width_long",
+        program=rasp.SelectorWidth(
+            rasp.Select(rasp.tokens, rasp.tokens, lambda key, query: key <= query).annotated(name="SE", encoding=rasp.Encoding.NUMERICAL)
+        ).annotated(name="SO", encoding=rasp.Encoding.CATEGORICAL),
+        vocab={'t0', 't1'},
+        test_input=['t0', 't0', 't0', 't1', 't1', 't0', 't0', 't1', 't1', 't0'],
+        expected_output=[6, 6, 6, 10, 10, 6, 6, 10, 10, 6],
+        max_seq_len=10,
+    ),
 ]
 
 


### PR DESCRIPTION
Added a test for long selector widths which have a miss match between RASP and CRAFT.
RASP outputs:   [6, 6, 6, 10, 10, 6, 6, 10, 10, 6]
CRAFT outputs: [6, 6, 6,   9,    9, 6, 6,  9,   9, 6] (discarding the BOS token in index 0)

Interestingly the test framework reports [1, 2, 3, 4, 5, 4, 5, 8, 9, 6] as the output which doesn't make any sense
