### PR TITLE
More descriptive error messages

### DIFF
--- a/tracr/compiler/craft_model_to_transformer.py
+++ b/tracr/compiler/craft_model_to_transformer.py
@@ -34,6 +34,12 @@ def craft_model_to_transformer(
 ) -> assemble.AssembledTransformerModel:
   """Turn a craft model into a transformer model."""
 
+  if rasp.tokens.label not in graph.nodes:
+    raise ValueError(f'Failed to find a node with label {rasp.tokens.label}. '
+                     'This is probably because your RASP program does not include '
+                     'rasp.tokens. A program must include rasp.tokens to be '
+                     'compiled.')
+
   # Add the compiler BOS token.
   tokens_value_set = (
       graph.nodes[rasp.tokens.label][nodes.VALUE_SET].union(

--- a/tracr/rasp/rasp.py
+++ b/tracr/rasp/rasp.py
@@ -89,7 +89,7 @@ class _Annotations(collections.abc.Mapping):
       if key not in DEFAULT_ANNOTATORS:
         raise KeyError(
             f"No annotation exists for key '{key}'. "
-            f"Available keys: {list(*self.keys(), *DEFAULT_ANNOTATORS.keys())}")
+            f"Available keys: {set(self.keys()) | set(DEFAULT_ANNOTATORS.keys())}")
       self._inner_dict[key] = DEFAULT_ANNOTATORS[key](self._expr)
 
     return self._inner_dict[key]

--- a/tracr/rasp/rasp.py
+++ b/tracr/rasp/rasp.py
@@ -377,7 +377,7 @@ class SequenceMap(SOp):
   ):
     super().__init__()
 
-    if fst == snd:
+    if fst is snd:
       logging.warning("Creating a SequenceMap with both inputs being the same "
                       "SOp is discouraged. You should use a Map instead.")
 


### PR DESCRIPTION
## Issue:
Compiling a program without rasp.tokens raised a cryptic KeyError, e.g. the following raises `KeyError: 'tokens'`:
```
from tracr.rasp import rasp
from tracr.compiler import compiling

program = rasp.Map(lambda x: x, rasp.indices)
compiling.compile_rasp_to_model(program, vocab={1,2,3,4}, max_seq_len=5, compiler_bos="BOS")
```

## Proposed fix:
Raise a more descriptive error message.