### PR TITLE
Allow more inputs to rasp.Aggregate.

### DIFF
--- a/tracr/compiler/validating.py
+++ b/tracr/compiler/validating.py
@@ -127,13 +127,9 @@ class DynamicValidationEvaluator(rasp.DefaultRASPEvaluator):
       # a way to do this statically so we have to check this at runtime.
 
       agg_in = expr.sop(xs)
-      sel_width = rasp.SelectorWidth(expr.selector)(xs)
-      sel_width_val = max(sel_width) if sel_width else 0
-
       if (
-          rasp.is_categorical(expr)
-          and sel_width_val > 1
-          and set(agg_in) != set(out)
+          # The easiest way to satisfy this is to have a selector of width 1
+          rasp.is_categorical(expr) and not set(out).issubset(set(agg_in) | {None})
       ):
         self.unsupported_exprs.append(
             TracrUnsupportedExpr(

--- a/tracr/rasp/rasp.py
+++ b/tracr/rasp/rasp.py
@@ -932,16 +932,16 @@ def _get_selected(
 
 
 def _mean(xs: Sequence[VT], default: VT) -> VT:
-  """Takes the mean for numbers and concats for strings."""
+  """Takes the mean for numbers."""
   if not xs:
     return default
-  exemplar = xs[0]
-  if isinstance(exemplar, (int, bool)):
-    return sum(xs) / len(xs)
   elif len(xs) == 1:
-    return exemplar
+    return xs[0]
+  elif all(isinstance(x, (int, bool, float)) for x in xs):
+    return sum(xs) / len(xs)
   else:
-    raise ValueError(f"Unsupported type for aggregation: {xs}")
+    raise ValueError(f"Only types int, bool, and float are supported for aggregation. "
+                     f"Received sequence: {xs}")
 
 
 def _raise_not_implemented(expr: RASPExpr, xs: Sequence[Value]):


### PR DESCRIPTION
## Changes:
As discussed in #17 
1. Allow float inputs in rasp.Aggregate.
2. In validator, weaken validation condition slightly to check for subsets rather than equality.
3. Drop the check for selector width > 1 since it is redundant (if output domain is not a subset of the input domain, that implies selector width > 1)