### PR TITLE
Add directions

### DIFF
--- a/tracr/craft/bases.py
+++ b/tracr/craft/bases.py
@@ -171,7 +171,19 @@ class VectorInBasis:
       else:
         components.append(np.zeros_like(self.magnitudes[..., 0]))
     return VectorInBasis(list(basis), np.stack(components, axis=-1), basis_is_sorted=True)
-
+  
+  def add_directions(self, vector: "VectorInBasis") -> "VectorInBasis":
+    """
+    Equivalent to self += vector.project(self.basis)
+    This is to speed up accumulation into an output vector in the combine_in_parallel in vectorspace_fns
+    """
+    directions_indices = self.get_direction_to_index()
+    assert len(vector.basis_directions) == vector.magnitudes.shape[-1]
+    new_magnitudes = np.array(self.magnitudes)
+    for idx, basis in enumerate(vector.basis_directions):
+      new_magnitudes[..., directions_indices[basis]] += vector.magnitudes[..., idx]
+    return VectorInBasis(list(self.basis_directions), new_magnitudes, basis_is_sorted=True)
+  
 
 @dataclasses.dataclass
 class VectorSpaceWithBasis:

--- a/tracr/craft/bases.py
+++ b/tracr/craft/bases.py
@@ -51,9 +51,7 @@ class BasisDirection:
   
   @property
   def hash_value(self):
-      if not hasattr(self, '_hash_value'):
-          self._hash_value = hash((self.name, self.value))
-      return self._hash_value
+    return hash((self.name, self.value))
   
   def __eq__(self, other):
     return (self.name, self.value) == (other.name, other.value)

--- a/tracr/craft/vectorspace_fns.py
+++ b/tracr/craft/vectorspace_fns.py
@@ -103,7 +103,8 @@ class Linear(VectorFunction):
       for fn in fns:
         if x in fn.input_space:
           x_vec = fn.input_space.vector_from_basis_direction(x)
-          out += fn(x_vec).project(joint_output_space)
+          applied = fn(x_vec)
+          out = out.add_directions(applied)
       return out
 
     return cls.from_action(joint_input_space, joint_output_space, action)


### PR DESCRIPTION
Depends on PR #20
combine_in_parallel in vectorspace_fns is inefficient, iterating over a number of basis directions, applying a function to them, then projecting the result out to a large number of basis directions repeatedly. When instead this single value can be added to the basis directions accumulator directly without first projecting it to the same space.