### PR TITLE
Allow compiling programs with annotated tokens and indices & add tests

### DIFF
--- a/tracr/compiler/expr_to_craft_graph.py
+++ b/tracr/compiler/expr_to_craft_graph.py
@@ -92,7 +92,7 @@ def add_craft_components_to_rasp_graph(
       raise ValueError(
           "Craft components can only be added after basis inference.")
 
-    if expr is rasp.tokens or expr is rasp.indices:
+    if isinstance(expr, (rasp.TokensType, rasp.IndicesType)):
       block = None
     elif isinstance(expr, rasp.Map):
       inner_expr, inner_node = expr.inner, graph.nodes[expr.inner.label]

--- a/tracr/compiler/expr_to_craft_graph_test.py
+++ b/tracr/compiler/expr_to_craft_graph_test.py
@@ -75,7 +75,16 @@ class ExprToCraftGraphTest(parameterized.TestCase):
               rasp.tokens,
           )),
       dict(testcase_name="reverse", program=lib.make_reverse(rasp.tokens)),
-      dict(testcase_name="length", program=lib.make_length()))
+      dict(testcase_name="length", program=lib.make_length()),
+      dict(
+        testcase_name="annotated_tokens", 
+        program=rasp.annotate(rasp.tokens, foo="foo"),
+      ),
+      dict(
+        testcase_name="annotated_indices", 
+        program=rasp.annotate(rasp.indices, foo="foo"),
+      ),
+  )
   def test_compiling_rasp_programs(self, program):
     vocab = {0, 1, 2}
     extracted = rasp_to_graph.extract_rasp_graph(program)


### PR DESCRIPTION
As discussed in issue #15 

## Previously: 

A program that annotates rasp.tokens or rasp.indices would cause compilation to fail, e.g. 
```python
rasp.annotate(rasp.tokens, foo='foo')
```


## Fix (this PR):

Replace the check
```python
expr is rasp.tokens or expr is rasp.indices
```
in expr_to_rasp_graph.py with
```python
isinstance(expr, (rasp.TokensType, rasp.IndicesType)):
```

Also, add tests to confirm programs with annotated tokens/indices compile.

